### PR TITLE
feat: add sample module and refactor trace-response integration

### DIFF
--- a/buildSrc/src/main/kotlin/io/dopamine/build/ModuleConvention.kt
+++ b/buildSrc/src/main/kotlin/io/dopamine/build/ModuleConvention.kt
@@ -8,9 +8,10 @@ object ModuleConvention {
     val groups = listOf(
         "core",
         "docs",
+        "response",
+        "sample",
         "starter",
         "support",
-        "response",
         "trace"
     )
 

--- a/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/config/ResponseProperties.kt
+++ b/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/config/ResponseProperties.kt
@@ -41,14 +41,6 @@ data class ResponseProperties(
          */
         val includeTraceId: Boolean = true,
         /**
-         * The key name to use for traceId in the response (e.g., "traceId", "X-Trace-ID").
-         */
-        val traceIdKey: String = "traceId",
-        /**
-         * The request header name from which to extract the traceId.
-         */
-        val traceIdHeader: String = "X-Trace-ID",
-        /**
          * Whether to include paging information in the "meta" field.
          * Automatically extracted if the response contains Page<T> or similar.
          */

--- a/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/config/ResponsePropertyKeys.kt
+++ b/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/config/ResponsePropertyKeys.kt
@@ -10,8 +10,6 @@ object ResponsePropertyKeys {
         const val META_PREFIX = "$PREFIX.meta-options"
 
         const val INCLUDE_TRACE_ID = "$META_PREFIX.include-trace-id"
-        const val TRACE_ID_KEY = "$META_PREFIX.trace-id-key"
-        const val TRACE_ID_HEADER = "$META_PREFIX.trace-id-header"
         const val INCLUDE_PAGING = "$META_PREFIX.include-paging"
     }
 }

--- a/modules/response/dopamine-response-mvc/src/main/kotlin/io/dopamine/response/mvc/advice/DopamineResponseAdvice.kt
+++ b/modules/response/dopamine-response-mvc/src/main/kotlin/io/dopamine/response/mvc/advice/DopamineResponseAdvice.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.dopamine.response.core.factory.DopamineResponseFactory
 import io.dopamine.response.core.model.DopamineResponse
 import io.dopamine.trace.core.resolver.TraceIdResolver
+import io.dopamine.trace.mvc.config.TraceProperties
 import io.dopamine.trace.mvc.request.ServletTraceContext
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.core.MethodParameter
@@ -12,17 +13,18 @@ import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageConverter
 import org.springframework.http.server.ServerHttpRequest
 import org.springframework.http.server.ServerHttpResponse
-import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
 
 /**
- * Intercepts all controller responses and wraps them in DopamineResponse<T>.
- * This ensures a consistent response structure across all REST APIs.
+ * Intercepts all REST controller responses and wraps them in a standardized [DopamineResponse] format.
+ * If traceId is available, it is added to the meta field (if not already present).
  */
-@ControllerAdvice
+@RestControllerAdvice
 class DopamineResponseAdvice(
     private val factory: DopamineResponseFactory,
     private val traceIdResolver: TraceIdResolver,
+    private val traceProperties: TraceProperties,
     private val objectMapper: ObjectMapper,
     private val request: HttpServletRequest,
 ) : ResponseBodyAdvice<Any> {
@@ -31,7 +33,6 @@ class DopamineResponseAdvice(
         converterType: Class<out HttpMessageConverter<*>>,
     ): Boolean {
         val clazz = returnType.parameterType
-
         return !DopamineResponse::class.java.isAssignableFrom(clazz) &&
             !ResponseEntity::class.java.isAssignableFrom(clazz) &&
             !clazz.name.startsWith("reactor.core.publisher.")
@@ -45,25 +46,46 @@ class DopamineResponseAdvice(
         req: ServerHttpRequest,
         res: ServerHttpResponse,
     ): Any? {
-        // Skip reactive types
-        if (isReactive(body)) return body
+        // Skip reactive types or already wrapped response entities
+        if (isReactive(body) || body is ResponseEntity<*>) return body
 
-        // Skip ResponseEntity (already has status/header control)
-        if (body is ResponseEntity<*>) return body
-
-        // Build context
         val context = ServletTraceContext(request)
         val traceId = traceIdResolver.resolve(context)
 
-        // Wrap
-        val wrapped = factory.success(body, traceId)
+        return when (body) {
+            is DopamineResponse<*> -> {
+                val mergedMeta = mergeMeta(body.meta, traceId)
+                body.copy(meta = mergedMeta)
+            }
 
-        // Handle String return type
-        return if (returnType.parameterType == String::class.java) {
-            objectMapper.writeValueAsString(wrapped)
-        } else {
-            wrapped
+            else -> {
+                val meta = buildMeta(traceId)
+                val wrapped = factory.success(data = body, meta = meta)
+
+                // Special case: when controller returns a raw String
+                if (returnType.parameterType == String::class.java) {
+                    objectMapper.writeValueAsString(wrapped)
+                } else {
+                    wrapped
+                }
+            }
         }
+    }
+
+    private fun buildMeta(traceId: String?): Map<String, Any> {
+        if (traceId.isNullOrBlank()) return emptyMap()
+        return mapOf(traceProperties.traceIdKey to traceId)
+    }
+
+    private fun mergeMeta(
+        existing: Map<String, Any>?,
+        traceId: String?,
+        key: String = traceProperties.traceIdKey,
+    ): Map<String, Any> {
+        if (traceId.isNullOrBlank()) return existing ?: emptyMap()
+        val merged = existing?.toMutableMap() ?: mutableMapOf()
+        merged.putIfAbsent(key, traceId)
+        return merged
     }
 
     private fun isReactive(body: Any?): Boolean {

--- a/modules/sample/dopamine-starter-mvc-sample/build.gradle.kts
+++ b/modules/sample/dopamine-starter-mvc-sample/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+}
+
+dependencies {
+    implementation(project(":modules:starter:dopamine-starter-mvc"))
+
+    implementation(libs.spring.boot.starter.web)
+    testImplementation(libs.spring.boot.starter.test)
+}

--- a/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/DopamineStarterMvcSampleApplication.kt
+++ b/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/DopamineStarterMvcSampleApplication.kt
@@ -1,0 +1,11 @@
+package io.dopamine.starter.mvc.sample
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class DopamineStarterMvcSampleApplication
+
+fun main(args: Array<String>) {
+    runApplication<DopamineStarterMvcSampleApplication>(*args)
+}

--- a/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/controller/SampleController.kt
+++ b/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/controller/SampleController.kt
@@ -1,0 +1,53 @@
+package io.dopamine.starter.mvc.sample.controller
+
+import io.dopamine.starter.mvc.sample.dto.SampleDetailDto
+import io.dopamine.starter.mvc.sample.dto.SampleResponseDto
+import io.dopamine.starter.mvc.sample.dto.SampleStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+
+@RestController
+@RequestMapping("/sample")
+class SampleController {
+    @GetMapping("/string")
+    fun getString(): String = "hello world"
+
+    @GetMapping("/dto")
+    fun getDto(): SampleResponseDto =
+        SampleResponseDto(
+            id = 42L,
+            name = "Dopamine",
+            status = SampleStatus.ACTIVE,
+            createdAt = LocalDateTime.now(),
+            tags = listOf("infra", "spring-boot", "starter"),
+            details =
+                SampleDetailDto(
+                    description = "This is a detailed description of the sample.",
+                    score = 87,
+                ),
+            optionalField = "optional value",
+        )
+
+    @GetMapping("/list")
+    fun getList(): List<SampleResponseDto> =
+        listOf(
+            getDto(),
+            getDto().copy(id = 43L, name = "Dopamine-2", status = SampleStatus.INACTIVE),
+        )
+
+    @GetMapping("/map")
+    fun getMap(): Map<String, Any> =
+        mapOf(
+            "message" to "map response",
+            "value" to 123,
+            "success" to true,
+        )
+
+    @GetMapping("/null")
+    fun getNull(): String? = null
+
+    @GetMapping("/error")
+    fun getError(): Nothing = throw IllegalStateException("Intentional error for testing.")
+}

--- a/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/dto/SampleDetailDto.kt
+++ b/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/dto/SampleDetailDto.kt
@@ -1,0 +1,6 @@
+package io.dopamine.starter.mvc.sample.dto
+
+data class SampleDetailDto(
+    val description: String,
+    val score: Int,
+)

--- a/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/dto/SampleResponseDto.kt
+++ b/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/dto/SampleResponseDto.kt
@@ -1,0 +1,13 @@
+package io.dopamine.starter.mvc.sample.dto
+
+import java.time.LocalDateTime
+
+data class SampleResponseDto(
+    val id: Long,
+    val name: String,
+    val status: SampleStatus,
+    val createdAt: LocalDateTime,
+    val tags: List<String>,
+    val details: SampleDetailDto,
+    val optionalField: String? = null,
+)

--- a/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/dto/SampleStatus.kt
+++ b/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/dto/SampleStatus.kt
@@ -1,0 +1,7 @@
+package io.dopamine.starter.mvc.sample.dto
+
+enum class SampleStatus {
+    ACTIVE,
+    INACTIVE,
+    PENDING,
+}

--- a/modules/sample/dopamine-starter-mvc-sample/src/main/resources/application.yml
+++ b/modules/sample/dopamine-starter-mvc-sample/src/main/resources/application.yml
@@ -1,0 +1,1 @@
+spring.application.name=dopamine-starter-mvc-sample

--- a/modules/sample/dopamine-starter-mvc-sample/src/main/resources/application.yml
+++ b/modules/sample/dopamine-starter-mvc-sample/src/main/resources/application.yml
@@ -1,1 +1,13 @@
-spring.application.name=dopamine-starter-mvc-sample
+dopamine:
+  response:
+    enabled: true
+    include-meta: true
+    meta-options:
+      include-trace-id: true
+
+  docs:
+    enabled: true
+
+  trace:
+    trace-id-header: X-Trace-ID
+    trace-id-key: traceId

--- a/modules/sample/dopamine-starter-mvc-sample/src/test/kotlin/io/dopamine/starter/mvc/sample/DopamineStarterMvcSampleApplicationTests.kt
+++ b/modules/sample/dopamine-starter-mvc-sample/src/test/kotlin/io/dopamine/starter/mvc/sample/DopamineStarterMvcSampleApplicationTests.kt
@@ -5,9 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class DopamineStarterMvcSampleApplicationTests {
-
     @Test
     fun contextLoads() {
     }
-
 }

--- a/modules/sample/dopamine-starter-mvc-sample/src/test/kotlin/io/dopamine/starter/mvc/sample/DopamineStarterMvcSampleApplicationTests.kt
+++ b/modules/sample/dopamine-starter-mvc-sample/src/test/kotlin/io/dopamine/starter/mvc/sample/DopamineStarterMvcSampleApplicationTests.kt
@@ -1,0 +1,13 @@
+package io.dopamine.starter.mvc.sample
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class DopamineStarterMvcSampleApplicationTests {
+
+    @Test
+    fun contextLoads() {
+    }
+
+}

--- a/modules/starter/dopamine-starter-mvc/src/main/kotlin/io/dopamine/starter/mvc/response/ResponseAutoConfiguration.kt
+++ b/modules/starter/dopamine-starter-mvc/src/main/kotlin/io/dopamine/starter/mvc/response/ResponseAutoConfiguration.kt
@@ -6,6 +6,7 @@ import io.dopamine.response.core.config.ResponsePropertyKeys
 import io.dopamine.response.core.factory.DopamineResponseFactory
 import io.dopamine.response.mvc.advice.DopamineResponseAdvice
 import io.dopamine.trace.core.resolver.TraceIdResolver
+import io.dopamine.trace.mvc.config.TraceProperties
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -28,8 +29,9 @@ class ResponseAutoConfiguration {
     @Bean
     fun dopamineResponseAdvice(
         factory: DopamineResponseFactory,
+        traceIdResolver: TraceIdResolver,
+        traceProperties: TraceProperties,
         objectMapper: ObjectMapper,
         request: HttpServletRequest,
-        traceIdResolver: TraceIdResolver,
-    ): DopamineResponseAdvice = DopamineResponseAdvice(factory, traceIdResolver, objectMapper, request)
+    ): DopamineResponseAdvice = DopamineResponseAdvice(factory, traceIdResolver, traceProperties, objectMapper, request)
 }

--- a/modules/starter/dopamine-starter-mvc/src/main/kotlin/io/dopamine/starter/mvc/response/TraceIdResolverConfig.kt
+++ b/modules/starter/dopamine-starter-mvc/src/main/kotlin/io/dopamine/starter/mvc/response/TraceIdResolverConfig.kt
@@ -12,17 +12,10 @@ import org.springframework.context.annotation.Bean
 @AutoConfiguration
 class TraceIdResolverConfig {
     @Bean
-    fun headerTraceIdResolver(props: ResponseProperties): HeaderTraceIdResolver =
-        HeaderTraceIdResolver(props.metaOptions.traceIdHeader)
-
-    @Bean
-    fun mdcTraceIdResolver(props: ResponseProperties): MdcTraceIdResolver =
-        MdcTraceIdResolver(props.metaOptions.traceIdKey)
-
-    @Bean
-    @ConditionalOnMissingBean
-    fun traceIdResolver(
-        header: HeaderTraceIdResolver,
-        mdc: MdcTraceIdResolver,
-    ): TraceIdResolver = CompositeTraceIdResolver(listOf(header, mdc))
+    @ConditionalOnMissingBean(TraceIdResolver::class)
+    fun traceIdResolver(props: ResponseProperties): TraceIdResolver {
+        val header = HeaderTraceIdResolver(props.metaOptions.traceIdHeader)
+        val mdc = MdcTraceIdResolver(props.metaOptions.traceIdKey)
+        return CompositeTraceIdResolver(listOf(header, mdc))
+    }
 }

--- a/modules/starter/dopamine-starter-mvc/src/main/kotlin/io/dopamine/starter/mvc/response/TraceIdResolverConfig.kt
+++ b/modules/starter/dopamine-starter-mvc/src/main/kotlin/io/dopamine/starter/mvc/response/TraceIdResolverConfig.kt
@@ -1,9 +1,9 @@
 package io.dopamine.starter.mvc.response
 
-import io.dopamine.response.core.config.ResponseProperties
 import io.dopamine.trace.core.resolver.CompositeTraceIdResolver
 import io.dopamine.trace.core.resolver.HeaderTraceIdResolver
 import io.dopamine.trace.core.resolver.TraceIdResolver
+import io.dopamine.trace.mvc.config.TraceProperties
 import io.dopamine.trace.mvc.resolver.MdcTraceIdResolver
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -13,9 +13,9 @@ import org.springframework.context.annotation.Bean
 class TraceIdResolverConfig {
     @Bean
     @ConditionalOnMissingBean(TraceIdResolver::class)
-    fun traceIdResolver(props: ResponseProperties): TraceIdResolver {
-        val header = HeaderTraceIdResolver(props.metaOptions.traceIdHeader)
-        val mdc = MdcTraceIdResolver(props.metaOptions.traceIdKey)
+    fun traceIdResolver(props: TraceProperties): TraceIdResolver {
+        val header = HeaderTraceIdResolver(props.traceIdHeader)
+        val mdc = MdcTraceIdResolver(props.traceIdKey)
         return CompositeTraceIdResolver(listOf(header, mdc))
     }
 }

--- a/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/TraceIdMvcAutoConfiguration.kt
+++ b/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/TraceIdMvcAutoConfiguration.kt
@@ -1,0 +1,49 @@
+package io.dopamine.trace.mvc
+
+import io.dopamine.trace.core.generator.TraceIdGenerator
+import io.dopamine.trace.core.generator.UuidTraceIdGenerator
+import io.dopamine.trace.core.store.TraceIdStore
+import io.dopamine.trace.mvc.config.TraceProperties
+import io.dopamine.trace.mvc.filter.TraceIdFilter
+import io.dopamine.trace.mvc.store.MdcTraceIdStore
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.core.Ordered
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * Autoconfiguration for traceId generation and storage in servlet-based environments.
+ *
+ * Registers:
+ * - [TraceIdGenerator]: generates a unique traceId for each request
+ * - [TraceIdStore]: stores the traceId in MDC
+ * - [TraceIdFilter]: servlet filter that manages the traceId lifecycle
+ *
+ * Configuration is bound to the `dopamine.trace` prefix via [TraceProperties].
+ */
+@AutoConfiguration
+@EnableConfigurationProperties(TraceProperties::class)
+class TraceIdMvcAutoConfiguration {
+    @Bean
+    @ConditionalOnMissingBean
+    fun traceIdGenerator(): TraceIdGenerator = UuidTraceIdGenerator()
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun traceIdStore(props: TraceProperties): TraceIdStore = MdcTraceIdStore(props.traceIdKey)
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun traceIdFilter(
+        generator: TraceIdGenerator,
+        store: TraceIdStore,
+    ): FilterRegistrationBean<OncePerRequestFilter> {
+        val filter = TraceIdFilter(generator, store)
+        return FilterRegistrationBean<OncePerRequestFilter>(filter).apply {
+            order = Ordered.HIGHEST_PRECEDENCE
+        }
+    }
+}

--- a/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/config/TraceProperties.kt
+++ b/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/config/TraceProperties.kt
@@ -1,0 +1,19 @@
+package io.dopamine.trace.mvc.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for Dopamine trace behavior.
+ * Bound to the "dopamine.trace" prefix in application settings.
+ */
+@ConfigurationProperties(TracePropertyKeys.PREFIX)
+data class TraceProperties(
+    /**
+     * The key name to use for traceId in the response (e.g., "traceId", "X-Trace-ID").
+     */
+    val traceIdKey: String = "traceId",
+    /**
+     * The request header name from which to extract the traceId.
+     */
+    val traceIdHeader: String = "X-Trace-ID",
+)

--- a/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/config/TracePropertyKeys.kt
+++ b/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/config/TracePropertyKeys.kt
@@ -1,0 +1,5 @@
+package io.dopamine.trace.mvc.config
+
+object TracePropertyKeys {
+    const val PREFIX = "dopamine.trace"
+}

--- a/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/filter/TraceIdFilter.kt
+++ b/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/filter/TraceIdFilter.kt
@@ -1,0 +1,33 @@
+package io.dopamine.trace.mvc.filter
+
+import io.dopamine.trace.core.generator.TraceIdGenerator
+import io.dopamine.trace.core.store.TraceIdStore
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * Servlet filter that generates and stores a traceId at the start of each request.
+ *
+ * The traceId is cleared after request completion. Designed for use with [TraceIdStore] and [TraceIdGenerator].
+ */
+class TraceIdFilter(
+    private val generator: TraceIdGenerator,
+    private val store: TraceIdStore,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val traceId = generator.generate()
+        store.setCurrentTraceId(traceId)
+
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            store.clear()
+        }
+    }
+}

--- a/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/store/MdcTraceIdStore.kt
+++ b/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/store/MdcTraceIdStore.kt
@@ -1,0 +1,23 @@
+package io.dopamine.trace.mvc.store
+
+import io.dopamine.trace.core.store.TraceIdStore
+import org.slf4j.MDC
+
+/**
+ * [TraceIdStore] implementation that stores traceId in SLF4J MDC.
+ *
+ * Typically used in servlet-based environments to make traceId available in logging context.
+ */
+class MdcTraceIdStore(
+    private val key: String,
+) : TraceIdStore {
+    override fun getCurrentTraceId(): String? = MDC.get(key)
+
+    override fun setCurrentTraceId(traceId: String) {
+        MDC.put(key, traceId)
+    }
+
+    override fun clear() {
+        MDC.remove(key)
+    }
+}

--- a/modules/trace/dopamine-trace-mvc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/trace/dopamine-trace-mvc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.dopamine.trace.mvc.TraceIdMvcAutoConfiguration

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ val moduleGroups = listOf(
     "core",
     "docs",
     "response",
+    "sample",
     "starter",
     "support",
     "trace"


### PR DESCRIPTION
- Added `dopamine-starter-mvc-sample` module with simple controller and DTO
- Identified and fixed issue where traceId was not injected into response meta
  - Cause: missing AutoConfiguration.imports in trace-mvc
  - Fix: added META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
- Refactored response-core to remove direct traceId handling
  - DopamineResponseFactory now takes meta externally
  - Meta construction moved to advice layer