### PR TITLE
feat(i18n): add i18n module and integrate with response message resolution

### DIFF
--- a/buildSrc/src/main/kotlin/io/dopamine/build/ModuleConvention.kt
+++ b/buildSrc/src/main/kotlin/io/dopamine/build/ModuleConvention.kt
@@ -8,6 +8,7 @@ object ModuleConvention {
     val groups = listOf(
         "core",
         "docs",
+        "i18n",
         "response",
         "sample",
         "starter",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-plugin" }
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 
 # SpringDoc
 springdoc-openapi-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }

--- a/modules/core/dopamine-core/src/main/kotlin/io/dopamine/core/code/ErrorCode.kt
+++ b/modules/core/dopamine-core/src/main/kotlin/io/dopamine/core/code/ErrorCode.kt
@@ -7,28 +7,29 @@ package io.dopamine.core.code
 enum class ErrorCode(
     val code: String,
     val defaultMessage: String,
+    val messageKey: String,
 ) {
     // Authentication & Authorization
-    UNAUTHORIZED("AUTH_401", "Authentication is required."),
-    FORBIDDEN("AUTH_403", "Access is forbidden."),
-    INVALID_TOKEN("AUTH_401_INVALID", "The token is invalid."),
-    TOKEN_EXPIRED("AUTH_401_EXPIRED", "The token has expired."),
+    UNAUTHORIZED("AUTH_401", "Authentication is required.", "dopamine.error.auth.401"),
+    FORBIDDEN("AUTH_403", "Access is forbidden.", "dopamine.error.auth.403"),
+    INVALID_TOKEN("AUTH_401_INVALID", "The token is invalid.", "dopamine.error.auth.401.invalid"),
+    TOKEN_EXPIRED("AUTH_401_EXPIRED", "The token has expired.", "dopamine.error.auth.401.expired"),
 
     // Validation
-    VALIDATION_FAILED("VALID_400", "The request is invalid."),
+    VALIDATION_FAILED("VALID_400", "The request is invalid.", "dopamine.error.valid.400"),
 
     // Domain
-    RESOURCE_NOT_FOUND("DOMAIN_404", "The requested resource was not found."),
-    CONFLICT("DOMAIN_409", "The resource already exists."),
-    BUSINESS_RULE_VIOLATION("DOMAIN_400_RULE", "Business rule violated."),
+    RESOURCE_NOT_FOUND("DOMAIN_404", "The requested resource was not found.", "dopamine.error.domain.404"),
+    CONFLICT("DOMAIN_409", "The resource already exists.", "dopamine.error.domain.409"),
+    BUSINESS_RULE_VIOLATION("DOMAIN_400_RULE", "Business rule violated.", "dopamine.error.domain.400.rule"),
 
     // System
-    INTERNAL_ERROR("SYS_500", "Internal server error."),
-    SERVICE_UNAVAILABLE("SYS_503", "Service is temporarily unavailable."),
+    INTERNAL_ERROR("SYS_500", "Internal server error.", "dopamine.error.sys.500"),
+    SERVICE_UNAVAILABLE("SYS_503", "Service is temporarily unavailable.", "dopamine.error.sys.503"),
 
     // External
-    GATEWAY_TIMEOUT("EXTERNAL_504", "External system timeout."),
-    BAD_GATEWAY("EXTERNAL_502", "External system error."),
+    GATEWAY_TIMEOUT("EXTERNAL_504", "External system timeout.", "dopamine.error.external.504"),
+    BAD_GATEWAY("EXTERNAL_502", "External system error.", "dopamine.error.external.502"),
     ;
 
     companion object {

--- a/modules/core/dopamine-core/src/main/kotlin/io/dopamine/core/code/SuccessCode.kt
+++ b/modules/core/dopamine-core/src/main/kotlin/io/dopamine/core/code/SuccessCode.kt
@@ -11,11 +11,12 @@ enum class SuccessCode(
     val httpStatus: Int,
     val code: String,
     val defaultMessage: String,
+    val messageKey: String,
 ) {
-    SUCCESS(200, "${PREFIX}_200", "Request was successful."),
-    CREATED(201, "${PREFIX}_201", "Resource has been created."),
-    ACCEPTED(202, "${PREFIX}_202", "Request has been accepted."),
-    NO_CONTENT(204, "${PREFIX}_204", "No content."),
+    SUCCESS(200, "${PREFIX}_200", "Request was successful.", "dopamine.success.200"),
+    CREATED(201, "${PREFIX}_201", "Resource has been created.", "dopamine.success.201"),
+    ACCEPTED(202, "${PREFIX}_202", "Request has been accepted.", "dopamine.success.202"),
+    NO_CONTENT(204, "${PREFIX}_204", "No content.", "dopamine.success.204"),
     ;
 
     companion object {

--- a/modules/i18n/dopamine-i18n/build.gradle.kts
+++ b/modules/i18n/dopamine-i18n/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+}
+
+dependencies {
+    implementation(project(":modules:core:dopamine-core"))
+    implementation(libs.spring.boot.starter.web)
+}

--- a/modules/i18n/dopamine-i18n/build.gradle.kts
+++ b/modules/i18n/dopamine-i18n/build.gradle.kts
@@ -9,3 +9,12 @@ dependencies {
     implementation(project(":modules:core:dopamine-core"))
     implementation(libs.spring.boot.starter.web)
 }
+
+tasks.processResources {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.withType<Jar> {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from(sourceSets.main.get().resources)
+}

--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nAutoConfiguration.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nAutoConfiguration.kt
@@ -1,0 +1,33 @@
+package io.dopamine.i18n.config
+
+import io.dopamine.i18n.resolver.MessageResolver
+import io.dopamine.i18n.resolver.SpringMessageResolver
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.MessageSource
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.support.ReloadableResourceBundleMessageSource
+import java.util.Locale
+
+@Configuration
+@EnableConfigurationProperties(I18nProperties::class)
+class I18nAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(MessageSource::class)
+    fun messageSource(props: I18nProperties): MessageSource {
+        return ReloadableResourceBundleMessageSource().apply {
+            setBasename(props.basename)
+            setDefaultEncoding(props.encoding)
+            setFallbackToSystemLocale(props.fallbackToSystemLocale)
+            setDefaultLocale(Locale.forLanguageTag(props.defaultLocale))
+        }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(MessageResolver::class)
+    fun messageResolver(messageSource: MessageSource): MessageResolver {
+        return SpringMessageResolver(messageSource)
+    }
+}

--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nAutoConfiguration.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nAutoConfiguration.kt
@@ -13,21 +13,18 @@ import java.util.Locale
 @Configuration
 @EnableConfigurationProperties(I18nProperties::class)
 class I18nAutoConfiguration {
-
     @Bean
     @ConditionalOnMissingBean(MessageSource::class)
-    fun messageSource(props: I18nProperties): MessageSource {
-        return ReloadableResourceBundleMessageSource().apply {
-            setBasename(props.basename)
+    fun messageSource(props: I18nProperties): MessageSource =
+        ReloadableResourceBundleMessageSource().apply {
+            val finalBaseNameList = props.basenames + "classpath:/dopamine/messages"
+            setBasenames(*finalBaseNameList.toTypedArray())
             setDefaultEncoding(props.encoding)
             setFallbackToSystemLocale(props.fallbackToSystemLocale)
             setDefaultLocale(Locale.forLanguageTag(props.defaultLocale))
         }
-    }
 
     @Bean
     @ConditionalOnMissingBean(MessageResolver::class)
-    fun messageResolver(messageSource: MessageSource): MessageResolver {
-        return SpringMessageResolver(messageSource)
-    }
+    fun messageResolver(messageSource: MessageSource): MessageResolver = SpringMessageResolver(messageSource)
 }

--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nProperties.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nProperties.kt
@@ -9,9 +9,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(I18nPropertyKeys.PREFIX)
 data class I18nProperties(
     /**
-     * Base path of message bundles (e.g. "classpath:/messages").
+     * List of base paths for message bundles (e.g. classpath:/messages, classpath:/dopamine/messages)
      */
-    var basename: String = "classpath:/messages",
+    var basenames: List<String> = listOf("classpath:/messages"),
     /**
      * Default locale to use if none is specified (e.g. "en", "ko").
      */

--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nProperties.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nProperties.kt
@@ -1,0 +1,27 @@
+package io.dopamine.i18n.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for Dopamine i18n behavior.
+ * Bound to the "dopamine.i18n" prefix in application settings.
+ */
+@ConfigurationProperties(I18nPropertyKeys.PREFIX)
+data class I18nProperties(
+    /**
+     * Base path of message bundles (e.g. "classpath:/messages").
+     */
+    var basename: String = "classpath:/messages",
+    /**
+     * Default locale to use if none is specified (e.g. "en", "ko").
+     */
+    var defaultLocale: String = "en",
+    /**
+     * Encoding used to read message files (default: UTF-8).
+     */
+    var encoding: String = "UTF-8",
+    /**
+     * Whether to fall back to the JVM system locale.
+     */
+    var fallbackToSystemLocale: Boolean = true,
+)

--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nPropertyKeys.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nPropertyKeys.kt
@@ -1,0 +1,5 @@
+package io.dopamine.i18n.config
+
+object I18nPropertyKeys {
+    const val PREFIX = "dopamine.i18n"
+}

--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/MessageResolver.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/MessageResolver.kt
@@ -1,0 +1,12 @@
+package io.dopamine.i18n.resolver
+
+import java.util.Locale
+
+/**
+ * Resolves localized messages using a message key and locale.
+ *
+ * Typically used to retrieve i18n messages from resource bundles.
+ */
+fun interface MessageResolver {
+    fun resolve(key: String, locale: Locale): String
+}

--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/MessageResolver.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/MessageResolver.kt
@@ -8,5 +8,8 @@ import java.util.Locale
  * Typically used to retrieve i18n messages from resource bundles.
  */
 fun interface MessageResolver {
-    fun resolve(key: String, locale: Locale): String
+    fun resolve(
+        key: String,
+        locale: Locale,
+    ): String
 }

--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/SpringMessageResolver.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/SpringMessageResolver.kt
@@ -9,10 +9,10 @@ import java.util.Locale
  * If a message cannot be resolved, the key itself is returned as a fallback.
  */
 class SpringMessageResolver(
-    private val messageSource: MessageSource
+    private val messageSource: MessageSource,
 ) : MessageResolver {
-
-    override fun resolve(key: String, locale: Locale): String {
-        return messageSource.getMessage(key, null, null, locale) ?: key
-    }
+    override fun resolve(
+        key: String,
+        locale: Locale,
+    ): String = messageSource.getMessage(key, null, null, locale) ?: key
 }

--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/SpringMessageResolver.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/SpringMessageResolver.kt
@@ -1,0 +1,18 @@
+package io.dopamine.i18n.resolver
+
+import org.springframework.context.MessageSource
+import java.util.Locale
+
+/**
+ * [MessageResolver] implementation backed by Spring's [org.springframework.context.MessageSource].
+ *
+ * If a message cannot be resolved, the key itself is returned as a fallback.
+ */
+class SpringMessageResolver(
+    private val messageSource: MessageSource
+) : MessageResolver {
+
+    override fun resolve(key: String, locale: Locale): String {
+        return messageSource.getMessage(key, null, null, locale) ?: key
+    }
+}

--- a/modules/i18n/dopamine-i18n/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/i18n/dopamine-i18n/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.dopamine.i18n.config.I18nAutoConfiguration

--- a/modules/i18n/dopamine-i18n/src/main/resources/dopamine/messages.properties
+++ b/modules/i18n/dopamine-i18n/src/main/resources/dopamine/messages.properties
@@ -1,0 +1,27 @@
+# Success Messages
+dopamine.success.200=Request was successful.
+dopamine.success.201=Resource has been created.
+dopamine.success.202=Request has been accepted.
+dopamine.success.204=No content.
+
+# Error Messages - Auth
+dopamine.error.auth.401=Authentication is required.
+dopamine.error.auth.403=Access is forbidden.
+dopamine.error.auth.401.invalid=The token is invalid.
+dopamine.error.auth.401.expired=The token has expired.
+
+# Error Messages - Validation
+dopamine.error.valid.400=The request is invalid.
+
+# Error Messages - Domain
+dopamine.error.domain.404=The requested resource was not found.
+dopamine.error.domain.409=The resource already exists.
+dopamine.error.domain.400.rule=Business rule violated.
+
+# Error Messages - System
+dopamine.error.sys.500=Internal server error11.
+dopamine.error.sys.503=Service is temporarily unavailable.
+
+# Error Messages - External
+dopamine.error.external.504=External system timeout.
+dopamine.error.external.502=External system error.

--- a/modules/i18n/dopamine-i18n/src/main/resources/dopamine/messages_ko.properties
+++ b/modules/i18n/dopamine-i18n/src/main/resources/dopamine/messages_ko.properties
@@ -1,0 +1,27 @@
+# 공통 성공
+dopamine.success.200=요청이 성공적으로 처리되었습니다.
+dopamine.success.201=리소스가 성공적으로 생성되었습니다.
+dopamine.success.202=요청이 정상적으로 수락되었습니다.
+dopamine.success.204=응답할 내용이 없습니다.
+
+# 인증 관련 오류
+dopamine.error.auth.401=인증이 필요합니다.
+dopamine.error.auth.403=접근이 거부되었습니다.
+dopamine.error.auth.401.invalid=토큰이 유효하지 않습니다.
+dopamine.error.auth.401.expired=토큰이 만료되었습니다.
+
+# 검증 오류
+dopamine.error.valid.400=요청이 유효하지 않습니다.
+
+# 도메인 오류
+dopamine.error.domain.404=요청한 리소스를 찾을 수 없습니다.
+dopamine.error.domain.409=이미 존재하는 리소스입니다.
+dopamine.error.domain.400.rule=비즈니스 규칙을 위반하였습니다.
+
+# 시스템 오류
+dopamine.error.sys.500=내부 서버 오류가 발생했습니다.
+dopamine.error.sys.503=일시적으로 서비스를 이용할 수 없습니다.
+
+# 외부 시스템 오류
+dopamine.error.external.504=외부 시스템 응답이 지연되었습니다.
+dopamine.error.external.502=외부 시스템에서 오류가 발생했습니다.

--- a/modules/response/dopamine-response-core/build.gradle.kts
+++ b/modules/response/dopamine-response-core/build.gradle.kts
@@ -6,8 +6,10 @@ plugins {
 }
 
 dependencies {
+    api(project(":modules:i18n:dopamine-i18n"))
     implementation(project(":modules:core:dopamine-core"))
     implementation(libs.spring.boot.starter.web)
+    implementation(libs.kotlin.reflect)
 
     testImplementation(project(":modules:test:dopamine-test-support"))
     testImplementation(libs.kotest.runner.junit5)

--- a/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/config/CustomResponseCode.kt
+++ b/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/config/CustomResponseCode.kt
@@ -1,0 +1,20 @@
+package io.dopamine.response.core.config
+
+/**
+ * Custom response code structure mapped by HTTP status.
+ * Allows external configuration of response messages and internal codes.
+ *
+ * At least one of [message] or [messageKey] must be provided.
+ */
+data class CustomResponseCode(
+    val httpStatus: Int,
+    val code: String,
+    val message: String? = null,
+    val messageKey: String? = null,
+) {
+    init {
+        require(message != null || messageKey != null) {
+            "Either 'message' or 'messageKey' must be provided for CustomResponseCode(code=$code, httpStatus=$httpStatus)"
+        }
+    }
+}

--- a/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/config/ResponseProperties.kt
+++ b/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/config/ResponseProperties.kt
@@ -46,14 +46,4 @@ data class ResponseProperties(
          */
         val includePaging: Boolean = true,
     )
-
-    /**
-     * Custom response code structure mapped by HTTP status.
-     * Allows external configuration of response messages and internal codes.
-     */
-    data class CustomResponseCode(
-        val httpStatus: Int,
-        val code: String,
-        val message: String,
-    )
 }

--- a/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/exception/DopamineException.kt
+++ b/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/exception/DopamineException.kt
@@ -9,8 +9,9 @@ package io.dopamine.response.core.exception
  * It is used to generate standardized API error responses and supports
  * external message resolution (e.g., via message source or configuration).
  */
-open class DopamineException(
+class DopamineException(
     val code: String,
+    val messageKey: String? = null,
     override val message: String,
     override val cause: Throwable? = null,
 ) : RuntimeException(message, cause)

--- a/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/factory/DopamineResponseFactory.kt
+++ b/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/factory/DopamineResponseFactory.kt
@@ -14,7 +14,6 @@ import java.time.LocalDateTime
  * Formatting, timestamp generation, and response code mapping are handled here.
  * Optional traceId or meta can be injected externally.
  */
-
 @Component
 class DopamineResponseFactory(
     private val props: ResponseProperties,

--- a/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/factory/DopamineResponseFactory.kt
+++ b/modules/response/dopamine-response-core/src/main/kotlin/io/dopamine/response/core/factory/DopamineResponseFactory.kt
@@ -1,13 +1,16 @@
 package io.dopamine.response.core.factory
 
 import io.dopamine.core.code.SuccessCode
+import io.dopamine.i18n.resolver.MessageResolver
 import io.dopamine.response.core.code.fromHttpStatus
+import io.dopamine.response.core.config.CustomResponseCode
 import io.dopamine.response.core.config.ResponseProperties
 import io.dopamine.response.core.model.DopamineResponse
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
+import java.util.Locale
 
 /**
  * Factory responsible for constructing standardized DopamineResponse<T> instances.
@@ -17,6 +20,7 @@ import java.time.LocalDateTime
 @Component
 class DopamineResponseFactory(
     private val props: ResponseProperties,
+    private val messageResolver: MessageResolver,
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -62,7 +66,7 @@ class DopamineResponseFactory(
 
     private fun formatTimestamp(): String = LocalDateTime.now().format(props.timestampFormat.formatter())
 
-    private val customCodeMap: Map<Int, Pair<String, String>> by lazy {
+    private val customCodeMap: Map<Int, CustomResponseCode> by lazy {
         props.codes
             .groupBy { it.httpStatus }
             .mapValues { entry ->
@@ -74,16 +78,36 @@ class DopamineResponseFactory(
                         duplicates.first(),
                     )
                 }
-                val first = duplicates.first()
-                first.code to first.message
+                duplicates.first()
             }
     }
 
-    private fun resolveCode(status: HttpStatus): Pair<String, String> {
-        customCodeMap[status.value()]?.let { return it }
+    private fun resolveCode(
+        status: HttpStatus,
+        locale: Locale = Locale.getDefault(),
+    ): Pair<String, String> {
+        customCodeMap[status.value()]?.let { config ->
+            val message =
+                config.messageKey?.let { key ->
+                    val resolved = messageResolver.resolve(key, locale)
+                    if (resolved != key) resolved else null
+                } ?: config.message
+
+            val finalMessage =
+                message
+                    ?: SuccessCode.fromHttpStatusCode(status.value())?.let {
+                        val resolved = messageResolver.resolve(it.messageKey, locale)
+                        if (resolved != it.messageKey) resolved else it.defaultMessage
+                    }
+                    ?: status.reasonPhrase
+
+            return config.code to finalMessage
+        }
 
         SuccessCode.fromHttpStatus(status)?.let {
-            return it.code to it.defaultMessage
+            val resolved = messageResolver.resolve(it.messageKey, locale)
+            val message = if (resolved != it.messageKey) resolved else it.defaultMessage
+            return it.code to message
         }
 
         return status.name to status.reasonPhrase

--- a/modules/response/dopamine-response-core/src/test/kotlin/io/dopamine/response/core/factory/DopamineResponseFactoryTest.kt
+++ b/modules/response/dopamine-response-core/src/test/kotlin/io/dopamine/response/core/factory/DopamineResponseFactoryTest.kt
@@ -1,8 +1,8 @@
 package io.dopamine.response.core.factory
 
 import io.dopamine.core.code.SuccessCode
+import io.dopamine.response.core.config.CustomResponseCode
 import io.dopamine.response.core.config.ResponseProperties
-import io.dopamine.response.core.config.ResponseProperties.CustomResponseCode
 import io.dopamine.response.core.format.TimestampFormat
 import io.dopamine.response.core.model.DopamineResponse
 import io.dopamine.test.support.assertion.ExpectedResponse

--- a/modules/response/dopamine-response-mvc/build.gradle.kts
+++ b/modules/response/dopamine-response-mvc/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
 dependencies {
     api(project(":modules:response:dopamine-response-core"))
     api(project(":modules:trace:dopamine-trace-mvc"))
+    implementation(project(":modules:i18n:dopamine-i18n"))
     implementation(libs.spring.boot.starter.web)
+
     testImplementation(libs.spring.boot.starter.test)
 }

--- a/modules/response/dopamine-response-mvc/build.gradle.kts
+++ b/modules/response/dopamine-response-mvc/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 dependencies {
     api(project(":modules:response:dopamine-response-core"))
     api(project(":modules:trace:dopamine-trace-mvc"))
-    implementation(project(":modules:i18n:dopamine-i18n"))
     implementation(libs.spring.boot.starter.web)
 
     testImplementation(libs.spring.boot.starter.test)

--- a/modules/response/dopamine-response-mvc/src/main/kotlin/io/dopamine/response/mvc/advice/DopamineErrorResponseAdvice.kt
+++ b/modules/response/dopamine-response-mvc/src/main/kotlin/io/dopamine/response/mvc/advice/DopamineErrorResponseAdvice.kt
@@ -20,6 +20,7 @@ class DopamineErrorResponseAdvice(
     @ExceptionHandler(DopamineException::class)
     fun handleDopamineException(e: DopamineException): ResponseEntity<DopamineResponse<Nothing>> {
         val meta = metaBuilder.build()
+
         val response =
             factory.of(
                 data = null,

--- a/modules/sample/dopamine-starter-mvc-sample/src/main/resources/application.yml
+++ b/modules/sample/dopamine-starter-mvc-sample/src/main/resources/application.yml
@@ -2,9 +2,9 @@ dopamine:
   response:
     enabled: true
     include-meta: true
+    timestampFormat: ISO_8601
     meta-options:
       include-trace-id: true
-
   docs:
     enabled: true
 

--- a/modules/starter/dopamine-starter-mvc/src/main/kotlin/io/dopamine/starter/mvc/config/ResponseAutoConfiguration.kt
+++ b/modules/starter/dopamine-starter-mvc/src/main/kotlin/io/dopamine/starter/mvc/config/ResponseAutoConfiguration.kt
@@ -1,6 +1,7 @@
-package io.dopamine.starter.mvc.response
+package io.dopamine.starter.mvc.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.dopamine.i18n.resolver.MessageResolver
 import io.dopamine.response.core.config.ResponseProperties
 import io.dopamine.response.core.config.ResponsePropertyKeys
 import io.dopamine.response.core.factory.DopamineResponseFactory
@@ -26,7 +27,10 @@ import org.springframework.context.annotation.Bean
 @EnableConfigurationProperties(ResponseProperties::class)
 class ResponseAutoConfiguration {
     @Bean
-    fun dopamineResponseFactory(props: ResponseProperties): DopamineResponseFactory = DopamineResponseFactory(props)
+    fun dopamineResponseFactory(
+        props: ResponseProperties,
+        messageResolver: MessageResolver,
+    ): DopamineResponseFactory = DopamineResponseFactory(props, messageResolver)
 
     @Bean
     fun responseMetaBuilder(

--- a/modules/starter/dopamine-starter-mvc/src/main/kotlin/io/dopamine/starter/mvc/config/TraceIdResolverConfig.kt
+++ b/modules/starter/dopamine-starter-mvc/src/main/kotlin/io/dopamine/starter/mvc/config/TraceIdResolverConfig.kt
@@ -1,4 +1,4 @@
-package io.dopamine.starter.mvc.response
+package io.dopamine.starter.mvc.config
 
 import io.dopamine.trace.core.resolver.CompositeTraceIdResolver
 import io.dopamine.trace.core.resolver.HeaderTraceIdResolver

--- a/modules/starter/dopamine-starter-mvc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/starter/dopamine-starter-mvc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,2 @@
-io.dopamine.starter.mvc.response.ResponseAutoConfiguration
-io.dopamine.starter.mvc.response.TraceIdResolverConfig
+io.dopamine.starter.mvc.config.ResponseAutoConfiguration
+io.dopamine.starter.mvc.config.TraceIdResolverConfig

--- a/modules/test/dopamine-test-support/src/main/kotlin/io/dopamine/test/support/factory/DopamineResponseFactoryFixtures.kt
+++ b/modules/test/dopamine-test-support/src/main/kotlin/io/dopamine/test/support/factory/DopamineResponseFactoryFixtures.kt
@@ -1,9 +1,12 @@
 package io.dopamine.test.support.factory
 
+import io.dopamine.i18n.resolver.MessageResolver
 import io.dopamine.response.core.config.ResponseProperties
 import io.dopamine.response.core.factory.DopamineResponseFactory
 
 object DopamineResponseFactoryFixtures {
-    fun dummy(props: ResponseProperties = ResponseProperties()): DopamineResponseFactory =
-        DopamineResponseFactory(props)
+    fun dummy(
+        props: ResponseProperties = ResponseProperties(),
+        messageResolver: MessageResolver = MessageResolver { key, _ -> key },
+    ): DopamineResponseFactory = DopamineResponseFactory(props, messageResolver)
 }

--- a/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/config/TraceIdMvcAutoConfiguration.kt
+++ b/modules/trace/dopamine-trace-mvc/src/main/kotlin/io/dopamine/trace/mvc/config/TraceIdMvcAutoConfiguration.kt
@@ -1,9 +1,8 @@
-package io.dopamine.trace.mvc
+package io.dopamine.trace.mvc.config
 
 import io.dopamine.trace.core.generator.TraceIdGenerator
 import io.dopamine.trace.core.generator.UuidTraceIdGenerator
 import io.dopamine.trace.core.store.TraceIdStore
-import io.dopamine.trace.mvc.config.TraceProperties
 import io.dopamine.trace.mvc.filter.TraceIdFilter
 import io.dopamine.trace.mvc.store.MdcTraceIdStore
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -18,9 +17,9 @@ import org.springframework.web.filter.OncePerRequestFilter
  * Autoconfiguration for traceId generation and storage in servlet-based environments.
  *
  * Registers:
- * - [TraceIdGenerator]: generates a unique traceId for each request
- * - [TraceIdStore]: stores the traceId in MDC
- * - [TraceIdFilter]: servlet filter that manages the traceId lifecycle
+ * - [io.dopamine.trace.core.generator.TraceIdGenerator]: generates a unique traceId for each request
+ * - [io.dopamine.trace.core.store.TraceIdStore]: stores the traceId in MDC
+ * - [io.dopamine.trace.mvc.filter.TraceIdFilter]: servlet filter that manages the traceId lifecycle
  *
  * Configuration is bound to the `dopamine.trace` prefix via [TraceProperties].
  */

--- a/modules/trace/dopamine-trace-mvc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/trace/dopamine-trace-mvc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,1 @@
-io.dopamine.trace.mvc.TraceIdMvcAutoConfiguration
+io.dopamine.trace.mvc.config.TraceIdMvcAutoConfiguration

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "dopamine"
 val moduleGroups = listOf(
     "core",
     "docs",
+    "i18n",
     "response",
     "sample",
     "starter",


### PR DESCRIPTION
Initial implementation of the `dopamine-i18n` module and integration with the response system for message resolution and internationalization support.

- Provides centralized i18n message resolution via `MessageResolver` interface
- Backed by Spring's `MessageSource` (with default fallback behavior)
- Supports user-defined message bundles and locales
- Automatically registers `ReloadableResourceBundleMessageSource`

### Base message bundle setup
- Added `messages.properties` (EN) and `messages_ko.properties` (KO)
- Includes default messages for common response codes (success/error)

### Response system integration
- Injected `MessageResolver` into `DopamineResponseFactory`
- Applies fallback message resolution logic:
  1. `messageKey` from `CustomResponseCode`
  2. `message` from config
  3. Enum `messageKey` (SuccessCode/ErrorCode)
  4. Enum `defaultMessage`
  5. HTTP reason phrase