### PR TITLE
refactor(i18n): delegate message resolution to internationalization layer

### DIFF
--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/MessageResolver.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/MessageResolver.kt
@@ -1,7 +1,5 @@
 package io.dopamine.i18n.resolver
 
-import java.util.Locale
-
 /**
  * Resolves localized messages using a message key and locale.
  *
@@ -9,7 +7,7 @@ import java.util.Locale
  */
 fun interface MessageResolver {
     fun resolve(
-        key: String,
-        locale: Locale,
-    ): String
+        messageKey: String?,
+        defaultMessage: String?,
+    ): String?
 }

--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/SpringMessageResolver.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/resolver/SpringMessageResolver.kt
@@ -1,6 +1,8 @@
 package io.dopamine.i18n.resolver
 
 import org.springframework.context.MessageSource
+import org.springframework.context.NoSuchMessageException
+import org.springframework.context.i18n.LocaleContextHolder
 import java.util.Locale
 
 /**
@@ -10,9 +12,20 @@ import java.util.Locale
  */
 class SpringMessageResolver(
     private val messageSource: MessageSource,
+    private val localeProvider: () -> Locale = { LocaleContextHolder.getLocale() },
 ) : MessageResolver {
     override fun resolve(
-        key: String,
-        locale: Locale,
-    ): String = messageSource.getMessage(key, null, null, locale) ?: key
+        messageKey: String?,
+        defaultMessage: String?,
+    ): String? {
+        val locale = localeProvider()
+
+        return messageKey?.let {
+            try {
+                messageSource.getMessage(it, null, null, locale)
+            } catch (ex: NoSuchMessageException) {
+                defaultMessage
+            }
+        } ?: defaultMessage
+    }
 }

--- a/modules/response/dopamine-response-common/src/test/kotlin/io/dopamine/response/common/factory/DopamineResponseFactoryTest.kt
+++ b/modules/response/dopamine-response-common/src/test/kotlin/io/dopamine/response/common/factory/DopamineResponseFactoryTest.kt
@@ -4,10 +4,10 @@ import io.dopamine.response.common.code.DefaultSuccessCode
 import io.dopamine.response.common.config.CustomResponseCode
 import io.dopamine.response.common.config.ResponseProperties
 import io.dopamine.response.common.format.TimestampFormat
-import io.dopamine.response.common.model.DopamineResponse
 import io.dopamine.test.support.assertion.ExpectedResponse
 import io.dopamine.test.support.assertion.shouldBeSuccessWith
 import io.dopamine.test.support.factory.DopamineResponseFactoryFixtures
+import io.dopamine.test.support.factory.DopamineResponseFactoryFixtures.messageResolverWith
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.http.HttpStatus
@@ -19,23 +19,33 @@ class DopamineResponseFactoryTest :
         val defaultTraceId = "test-trace-id"
         val formatter: DateTimeFormatter = TimestampFormat.ISO_8601.formatter()
 
+        val baseMessageResolver =
+            messageResolverWith(
+                "dopamine.success.200" to "Request was successful.",
+                "dopamine.success.201" to "Resource has been created.",
+                "dopamine.error.500" to "Internal server error.",
+            )
+
+        val defaultProps =
+            ResponseProperties(
+                includeMeta = true,
+                timestampFormat = TimestampFormat.ISO_8601,
+            )
+
         lateinit var factory: DopamineResponseFactory
 
         beforeTest {
             factory =
                 DopamineResponseFactoryFixtures.dummy(
-                    props =
-                        ResponseProperties(
-                            includeMeta = true,
-                            timestampFormat = TimestampFormat.ISO_8601,
-                        ),
+                    props = defaultProps,
+                    messageResolver = baseMessageResolver,
                 )
         }
 
         context("success(...)") {
 
             test("should include traceId and timestamp when called with default settings") {
-                val response: DopamineResponse<String> = factory.success("hello", mapOf("traceId" to defaultTraceId))
+                val response = factory.success("hello", meta = mapOf("traceId" to defaultTraceId))
 
                 response shouldBeSuccessWith
                     ExpectedResponse(
@@ -48,19 +58,18 @@ class DopamineResponseFactoryTest :
             }
 
             test("should apply custom response code and message when defined in properties") {
-                val props =
-                    ResponseProperties(
-                        includeMeta = true,
-                        timestampFormat = TimestampFormat.ISO_8601,
-                        codes =
-                            listOf(
-                                CustomResponseCode(200, "Custom200", "Custom Success"),
-                            ),
+                val customProps =
+                    defaultProps.copy(
+                        codes = listOf(CustomResponseCode(200, "Custom200", "Custom Success")),
                     )
-                val factory =
-                    DopamineResponseFactoryFixtures.dummy(props = props)
 
-                val response = factory.success("hello", mapOf("traceId" to defaultTraceId))
+                val factory =
+                    DopamineResponseFactoryFixtures.dummy(
+                        props = customProps,
+                        messageResolver = baseMessageResolver,
+                    )
+
+                val response = factory.success("hello", meta = mapOf("traceId" to defaultTraceId))
 
                 response shouldBeSuccessWith
                     ExpectedResponse(
@@ -73,13 +82,15 @@ class DopamineResponseFactoryTest :
             }
 
             test("should return null meta when includeMeta is false") {
+                val noMetaProps = defaultProps.copy(includeMeta = false)
+
                 val factory =
                     DopamineResponseFactoryFixtures.dummy(
-                        props = ResponseProperties(includeMeta = false),
+                        props = noMetaProps,
+                        messageResolver = baseMessageResolver,
                     )
 
-                val response = factory.success("data", null)
-
+                val response = factory.success("data", meta = null)
                 response.meta shouldBe null
             }
         }

--- a/modules/response/dopamine-response-mvc/src/main/kotlin/io/dopamine/response/mvc/advice/DopamineErrorResponseAdvice.kt
+++ b/modules/response/dopamine-response-mvc/src/main/kotlin/io/dopamine/response/mvc/advice/DopamineErrorResponseAdvice.kt
@@ -1,12 +1,12 @@
 package io.dopamine.response.mvc.advice
 
+import io.dopamine.response.common.code.DefaultErrorCode
 import io.dopamine.response.common.exception.DopamineException
 import io.dopamine.response.common.factory.DopamineResponseFactory
 import io.dopamine.response.common.model.DopamineResponse
 import io.dopamine.response.mvc.meta.ResponseMetaBuilder
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -20,27 +20,30 @@ class DopamineErrorResponseAdvice(
     @ExceptionHandler(DopamineException::class)
     fun handleDopamineException(e: DopamineException): ResponseEntity<DopamineResponse<Nothing>> {
         val meta = metaBuilder.build()
+        val errorCode = DefaultErrorCode.BAD_REQUEST
 
         val response =
-            factory.of(
-                data = null,
-                status = HttpStatus.BAD_REQUEST,
-                customCode = e.code,
-                customMessage = e.message,
+            factory.fail(
+                responseCode = errorCode,
                 meta = meta,
             )
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response)
+        return ResponseEntity
+            .status(errorCode.httpStatus)
+            .body(response)
     }
 
     @ExceptionHandler(Exception::class)
     fun handleGenericException(e: Exception): ResponseEntity<DopamineResponse<Nothing>> {
         val meta = metaBuilder.build()
+        val errorCode = DefaultErrorCode.INTERNAL_SERVER_ERROR
         val response =
-            factory.of(
-                data = null,
-                status = HttpStatus.INTERNAL_SERVER_ERROR,
+            factory.fail(
+                responseCode = errorCode,
                 meta = meta,
             )
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response)
+
+        return ResponseEntity
+            .status(errorCode.httpStatus)
+            .body(response)
     }
 }

--- a/modules/test/dopamine-test-support/src/main/kotlin/io/dopamine/test/support/factory/DopamineResponseFactoryFixtures.kt
+++ b/modules/test/dopamine-test-support/src/main/kotlin/io/dopamine/test/support/factory/DopamineResponseFactoryFixtures.kt
@@ -7,6 +7,13 @@ import io.dopamine.response.common.factory.DopamineResponseFactory
 object DopamineResponseFactoryFixtures {
     fun dummy(
         props: ResponseProperties = ResponseProperties(),
-        messageResolver: MessageResolver = MessageResolver { key, _ -> key },
+        messageResolver: MessageResolver,
     ): DopamineResponseFactory = DopamineResponseFactory(props, messageResolver)
+
+    fun messageResolverWith(vararg pairs: Pair<String, String>): MessageResolver {
+        val map = pairs.toMap()
+        return MessageResolver { key, default ->
+            key?.let { map[it] } ?: default ?: ""
+        }
+    }
 }


### PR DESCRIPTION
- Refactored DopamineResponseFactory to delegate messageKey/message to MessageResolver
- Changed MessageResolver to return nullable String for better fallback control
- Maintained resolution priority: CustomResponseCode → DefaultCode
- Updated test fixtures and response factory tests to allow explicit resolver injection