### PR TITLE
feat(auth): implement base authentication infrastructure and auto-configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import io.dopamine.build.ModuleConvention
+import io.dopamine.build.ModuleConvention.ktlintExcludes
 import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -63,7 +64,7 @@ subprojects {
         outputToConsole.set(true)
 
         filter {
-            exclude("**/build/**", "**/generated/**")
+            exclude(ktlintExcludes)
         }
 
         reporters {

--- a/buildSrc/src/main/kotlin/io/dopamine/build/ModuleConvention.kt
+++ b/buildSrc/src/main/kotlin/io/dopamine/build/ModuleConvention.kt
@@ -6,6 +6,7 @@ object ModuleConvention {
     const val JVM_TARGET = "21"
 
     val groups = listOf(
+        "auth",
         "core",
         "docs",
         "file",
@@ -24,6 +25,13 @@ object ModuleConvention {
         "**/generated/**",
         "**/Dummy*",
         "**/*Kt.class"
+    )
+
+    val ktlintExcludes = listOf(
+        "**/build/**",
+        "**/generated/**",
+        "**/src/main/java/**",
+        "**/src/test/java/**",
     )
 
     fun allPaths(base: String = "modules"): List<String> =

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ ktlint-plugin = "12.2.0"
 ktlint-cli = "1.5.0"
 kotest = "5.8.1"
 kotest-spring = "1.3.0"
+jjwt = "0.12.6"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -18,6 +19,7 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-plugin" }
 [libraries]
 # Spring (version omitted: managed via BOM)
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
+spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
@@ -31,3 +33,8 @@ kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref 
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotest-extensions-spring = { module = "io.kotest.extensions:kotest-extensions-spring", version.ref = "kotest-spring" }
+
+# jjwt
+jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
+jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
+jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jjwt" }

--- a/modules/auth/dopamine-auth-common/build.gradle.kts
+++ b/modules/auth/dopamine-auth-common/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+}
+
+dependencies {
+    api(project(":modules:core:dopamine-core"))
+    implementation(libs.spring.boot.starter.web)
+}

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/AuthContext.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/AuthContext.kt
@@ -1,0 +1,16 @@
+package io.dopamine.auth.common.authentication
+
+/**
+ * Provides access to authentication information for the current request.
+ */
+interface AuthContext {
+    /**
+     * The authenticated user.
+     */
+    val principal: UserPrincipal
+
+    /**
+     * The authentication token used in the request.
+     */
+    val token: Token
+}

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/Token.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/Token.kt
@@ -1,0 +1,14 @@
+package io.dopamine.auth.common.authentication
+
+import java.time.Instant
+
+/**
+ * Represents a parsed authentication token.
+ */
+interface Token {
+    val value: String
+    val subject: String
+    val issuedAt: Instant
+    val expiresAt: Instant
+    val claims: Map<String, Any>
+}

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/TokenProvider.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/TokenProvider.kt
@@ -1,0 +1,21 @@
+package io.dopamine.auth.common.authentication
+
+/**
+ * Provides operations for issuing, parsing, and validating authentication tokens.
+ */
+interface TokenProvider {
+    /**
+     * Issues a new authentication token with the given payload.
+     */
+    fun generate(payload: Map<String, Any>): Token
+
+    /**
+     * Parses a raw token string into a [Token] object.
+     */
+    fun parse(rawToken: String): Token
+
+    /**
+     * Validates whether the given token is valid (e.g., not expired or malformed).
+     */
+    fun validate(token: Token): Boolean
+}

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/TokenStore.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/TokenStore.kt
@@ -1,0 +1,22 @@
+package io.dopamine.auth.common.authentication
+
+/**
+ * Provides a way to store and manage authentication tokens
+ * when using stateful strategies (e.g., refresh tokens, blacklist).
+ */
+interface TokenStore {
+    /**
+     * Persists a token for future validation.
+     */
+    fun save(token: Token)
+
+    /**
+     * Checks if the token is currently valid (e.g., not revoked).
+     */
+    fun isValid(token: Token): Boolean
+
+    /**
+     * Invalidates a token, typically for logout or revocation.
+     */
+    fun invalidate(token: Token)
+}

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/UserLookupService.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/UserLookupService.kt
@@ -1,0 +1,9 @@
+package io.dopamine.auth.common.authentication
+
+/**
+ * Provides a way to resolve a [UserPrincipal] based on identity information
+ * such as username or subject from the authentication token.
+ */
+fun interface UserLookupService {
+    fun load(identity: String): UserPrincipal?
+}

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/UserPrincipal.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authentication/UserPrincipal.kt
@@ -1,0 +1,16 @@
+package io.dopamine.auth.common.authentication
+
+/**
+ * Represents an authenticated user's identity and roles.
+ */
+interface UserPrincipal {
+    val id: String
+    val username: String
+    val roles: List<String>
+
+    /**
+     * Optional attributes for additional claims.
+     */
+    val attributes: Map<String, Any>
+        get() = emptyMap()
+}

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authorization/PermissionContext.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authorization/PermissionContext.kt
@@ -1,0 +1,20 @@
+package io.dopamine.auth.common.authorization
+
+import java.lang.reflect.Method
+
+/**
+ * Extracts the target resource ID for authorization checks.
+ */
+fun interface PermissionContext {
+    /**
+     * Resolves the target resource ID (e.g., orderId) from the method arguments.
+     *
+     * @param method the method being invoked
+     * @param args the actual argument values of the method
+     * @return the ID of the resource, or null if not found
+     */
+    fun resolveTargetId(
+        method: Method,
+        args: Array<Any?>,
+    ): Any?
+}

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authorization/PermissionProvider.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authorization/PermissionProvider.kt
@@ -1,0 +1,22 @@
+package io.dopamine.auth.common.authorization
+
+import io.dopamine.auth.common.authentication.UserPrincipal
+
+/**
+ * Determines whether a user has permission to perform a specific action on a resource.
+ */
+fun interface PermissionProvider {
+    /**
+     * @param user the authenticated user
+     * @param resource the target resource name (e.g., "ORDER", "PRODUCT")
+     * @param action the requested action (e.g., "READ", "UPDATE")
+     * @param targetId optional ID of the specific target (e.g., orderId = 123)
+     * @return true if the user is authorized, false otherwise
+     */
+    fun isAuthorized(
+        user: UserPrincipal,
+        resource: String,
+        action: String,
+        targetId: Any?,
+    ): Boolean
+}

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authorization/TargetId.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/authorization/TargetId.kt
@@ -1,0 +1,8 @@
+package io.dopamine.auth.common.authorization
+
+/**
+ * Marks a method parameter as the target resource ID for permission checks.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class TargetId

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/config/AuthProperties.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/config/AuthProperties.kt
@@ -1,0 +1,29 @@
+package io.dopamine.auth.common.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for Dopamine authentication behavior.
+ * Bound to the "dopamine.auth" prefix in application settings.
+ */
+@ConfigurationProperties(prefix = AuthPropertyKeys.PREFIX)
+class AuthProperties {
+    var enabled: Boolean = true
+
+    /**
+     * Token-related properties.
+     */
+    var token: Token = Token()
+
+    class Token {
+        /**
+         * Secret key used to sign JWT tokens (Base64-encoded or raw).
+         */
+        var secret: String = "dopamine-default-jwt-signing-key-256!"
+
+        /**
+         * Token expiration time in seconds.
+         */
+        var expirationSeconds: Long = 3600
+    }
+}

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/config/AuthPropertyKeys.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/config/AuthPropertyKeys.kt
@@ -1,0 +1,6 @@
+package io.dopamine.auth.common.config
+
+object AuthPropertyKeys {
+    const val PREFIX = "dopamine.auth"
+    const val ENABLED = "$PREFIX.enabled"
+}

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/exception/AuthException.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/exception/AuthException.kt
@@ -1,0 +1,9 @@
+package io.dopamine.auth.common.exception
+
+/**
+ * Base class for all authentication and authorization related exceptions.
+ */
+open class AuthException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/exception/InvalidTokenException.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/exception/InvalidTokenException.kt
@@ -1,0 +1,9 @@
+package io.dopamine.auth.common.exception
+
+/**
+ * Thrown when the authentication token is missing, malformed, or invalid.
+ */
+class InvalidTokenException(
+    message: String,
+    cause: Throwable? = null,
+) : AuthException(message, cause)

--- a/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/exception/PermissionDeniedException.kt
+++ b/modules/auth/dopamine-auth-common/src/main/kotlin/io/dopamine/auth/common/exception/PermissionDeniedException.kt
@@ -1,0 +1,9 @@
+package io.dopamine.auth.common.exception
+
+/**
+ * Thrown when the authenticated user does not have permission to access a resource.
+ */
+class PermissionDeniedException(
+    message: String,
+    cause: Throwable? = null,
+) : AuthException(message, cause)

--- a/modules/auth/dopamine-auth-mvc/build.gradle.kts
+++ b/modules/auth/dopamine-auth-mvc/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+}
+
+dependencies {
+    api(project(":modules:auth:dopamine-auth-common"))
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.security)
+
+    implementation(libs.jjwt.api)
+    runtimeOnly(libs.jjwt.impl)
+    runtimeOnly(libs.jjwt.jackson)
+}

--- a/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/config/AuthMvcAutoConfiguration.kt
+++ b/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/config/AuthMvcAutoConfiguration.kt
@@ -1,0 +1,29 @@
+package io.dopamine.auth.mvc.config
+
+import io.dopamine.auth.common.authentication.TokenProvider
+import io.dopamine.auth.common.authentication.TokenStore
+import io.dopamine.auth.common.authentication.UserLookupService
+import io.dopamine.auth.common.config.AuthProperties
+import io.dopamine.auth.mvc.internal.store.InMemoryTokenStore
+import io.dopamine.auth.mvc.internal.token.JwtTokenProvider
+import io.dopamine.auth.mvc.internal.user.InMemoryUserLookupService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(AuthProperties::class)
+class AuthMvcAutoConfiguration {
+    @Bean
+    @ConditionalOnMissingBean
+    fun tokenProvider(properties: AuthProperties): TokenProvider = JwtTokenProvider(properties)
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun userLookupService(): UserLookupService = InMemoryUserLookupService()
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun tokenStore(): TokenStore = InMemoryTokenStore()
+}

--- a/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/filter/JwtAuthenticationFilter.kt
+++ b/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/filter/JwtAuthenticationFilter.kt
@@ -1,0 +1,57 @@
+package io.dopamine.auth.mvc.filter
+
+import io.dopamine.auth.common.authentication.TokenProvider
+import io.dopamine.auth.common.authentication.UserLookupService
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * JWT authentication filter that resolves tokens and populates the SecurityContext.
+ */
+class JwtAuthenticationFilter(
+    private val tokenProvider: TokenProvider,
+    private val userProvider: UserLookupService,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val token = extractToken(request)
+
+        if (token != null && SecurityContextHolder.getContext().authentication == null) {
+            val parsed = tokenProvider.parse(token)
+
+            val principal = userProvider.load(parsed.subject)
+
+            if (principal != null) {
+                val auth =
+                    UsernamePasswordAuthenticationToken(
+                        principal,
+                        null,
+                        principal.roles.map { SimpleGrantedAuthority(it) },
+                    ).apply {
+                        details = WebAuthenticationDetailsSource().buildDetails(request)
+                    }
+
+                SecurityContextHolder.getContext().authentication = auth
+            }
+        }
+
+        filterChain.doFilter(request, response)
+    }
+
+    /**
+     * Extracts the token string from the Authorization header.
+     */
+    private fun extractToken(request: HttpServletRequest): String? {
+        val header = request.getHeader("Authorization") ?: return null
+        return if (header.startsWith("Bearer ")) header.removePrefix("Bearer ").trim() else null
+    }
+}

--- a/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/internal/store/InMemoryTokenStore.kt
+++ b/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/internal/store/InMemoryTokenStore.kt
@@ -1,0 +1,25 @@
+package io.dopamine.auth.mvc.internal.store
+
+import io.dopamine.auth.common.authentication.Token
+import io.dopamine.auth.common.authentication.TokenStore
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-memory implementation of [TokenStore] for testing or simple use cases.
+ */
+class InMemoryTokenStore : TokenStore {
+    private val store = ConcurrentHashMap<String, Token>()
+
+    override fun save(token: Token) {
+        store[token.value] = token
+    }
+
+    override fun isValid(token: Token): Boolean =
+        store[token.value]?.let {
+            it.expiresAt.isAfter(token.expiresAt) || it == token
+        } ?: true
+
+    override fun invalidate(token: Token) {
+        store.remove(token.value)
+    }
+}

--- a/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/internal/token/JwtToken.kt
+++ b/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/internal/token/JwtToken.kt
@@ -1,0 +1,12 @@
+package io.dopamine.auth.mvc.internal.token
+
+import io.dopamine.auth.common.authentication.Token
+import java.time.Instant
+
+data class JwtToken(
+    override val value: String,
+    override val subject: String,
+    override val issuedAt: Instant,
+    override val expiresAt: Instant,
+    override val claims: Map<String, Any>,
+) : Token

--- a/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/internal/token/TokenProvider.kt
+++ b/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/internal/token/TokenProvider.kt
@@ -1,0 +1,64 @@
+package io.dopamine.auth.mvc.internal.token
+
+import io.dopamine.auth.common.authentication.Token
+import io.dopamine.auth.common.authentication.TokenProvider
+import io.dopamine.auth.common.config.AuthProperties
+import io.dopamine.auth.common.exception.InvalidTokenException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import java.time.Instant
+import java.util.Date
+import javax.crypto.SecretKey
+
+/**
+ * Default JWT-based implementation of [TokenProvider] using HS256.
+ */
+class JwtTokenProvider(
+    private val properties: AuthProperties,
+) : TokenProvider {
+    private val key: SecretKey by lazy {
+        val secret = properties.token.secret
+        require(secret.isNotBlank()) { "JWT secret key must be configured" }
+        Keys.hmacShaKeyFor(secret.toByteArray())
+    }
+
+    override fun generate(payload: Map<String, Any>): Token {
+        val now = Instant.now()
+        val exp = now.plusSeconds(3600)
+        val builder =
+            Jwts
+                .builder()
+                .subject(payload["sub"]?.toString() ?: error("Missing subject"))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(exp))
+                .claims(payload)
+                .signWith(key)
+
+        val jwtString = builder.compact()
+        return JwtToken(jwtString, payload["sub"].toString(), now, exp, payload)
+    }
+
+    override fun parse(rawToken: String): Token =
+        try {
+            val parser =
+                Jwts
+                    .parser()
+                    .verifyWith(key)
+                    .build()
+
+            val jws = parser.parseSignedClaims(rawToken)
+            val claims = jws.getPayload()
+
+            JwtToken(
+                value = rawToken,
+                subject = claims.subject,
+                issuedAt = claims.issuedAt.toInstant(),
+                expiresAt = claims.expiration.toInstant(),
+                claims = claims,
+            )
+        } catch (e: Exception) {
+            throw InvalidTokenException("Invalid JWT token", e)
+        }
+
+    override fun validate(token: Token): Boolean = token.expiresAt.isAfter(Instant.now())
+}

--- a/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/internal/user/InMemoryUserLookupService.kt
+++ b/modules/auth/dopamine-auth-mvc/src/main/kotlin/io/dopamine/auth/mvc/internal/user/InMemoryUserLookupService.kt
@@ -1,0 +1,18 @@
+package io.dopamine.auth.mvc.internal.user
+
+import io.dopamine.auth.common.authentication.UserLookupService
+import io.dopamine.auth.common.authentication.UserPrincipal
+
+/**
+ * Default in-memory implementation of [UserLookupService].
+ * Always returns a fixed test user.
+ */
+class InMemoryUserLookupService : UserLookupService {
+    override fun load(identity: String): UserPrincipal? =
+        object : UserPrincipal {
+            override val id: String = identity
+            override val username: String = "test-$identity"
+            override val roles: List<String> = listOf("ROLE_USER")
+            override val attributes: Map<String, Any> = emptyMap()
+        }
+}

--- a/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nProperties.kt
+++ b/modules/i18n/dopamine-i18n/src/main/kotlin/io/dopamine/i18n/config/I18nProperties.kt
@@ -11,7 +11,7 @@ data class I18nProperties(
     /**
      * List of base paths for message bundles (e.g. classpath:/messages, classpath:/dopamine/messages)
      */
-    var basenames: List<String> = listOf("classpath:/messages"),
+    var baseNames: List<String> = listOf("classpath:/messages"),
     /**
      * Default locale to use if none is specified (e.g. "en", "ko").
      */

--- a/modules/starter/dopamine-starter-common/src/main/kotlin/io/dopamine/starter/common/autoconfig/i18n/I18nAutoConfiguration.kt
+++ b/modules/starter/dopamine-starter-common/src/main/kotlin/io/dopamine/starter/common/autoconfig/i18n/I18nAutoConfiguration.kt
@@ -18,7 +18,7 @@ class I18nAutoConfiguration {
     @ConditionalOnMissingBean(MessageSource::class)
     fun messageSource(props: I18nProperties): MessageSource =
         ReloadableResourceBundleMessageSource().apply {
-            val finalBaseNameList = props.basenames + "classpath:/dopamine/messages"
+            val finalBaseNameList = props.baseNames + "classpath:/dopamine/messages"
             setBasenames(*finalBaseNameList.toTypedArray())
             setDefaultEncoding(props.encoding)
             setFallbackToSystemLocale(props.fallbackToSystemLocale)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 rootProject.name = "dopamine"
 
 val moduleGroups = listOf(
+    "auth",
     "core",
     "docs",
     "file",


### PR DESCRIPTION
- Define core abstractions in auth-common: Token, UserPrincipal, TokenProvider, etc.
- Provide default implementations in auth-mvc: JwtTokenProvider, UserLookupService, TokenStore
- Introduce AuthProperties for external configuration support
- Enable extensibility via @ConditionalOnMissingBean in all core components