### PR TITLE
refactor: add sample endpoints for response wrapping tests

### DIFF
--- a/modules/response/dopamine-response-common/src/main/kotlin/io/dopamine/response/common/config/ResponseProperties.kt
+++ b/modules/response/dopamine-response-common/src/main/kotlin/io/dopamine/response/common/config/ResponseProperties.kt
@@ -21,7 +21,13 @@ data class ResponseProperties(
     /**
      * Paths to exclude from automatic response wrapping (e.g., Swagger UI, API docs).
      */
-    val ignorePaths: List<String> = listOf("/swagger-ui", "/v3/api-docs", "/h2-console"),
+    val ignorePaths: List<String> =
+        listOf(
+            "/swagger-ui",
+            "/v3/api-docs",
+            "/h2-console",
+            "/favicon.ico",
+        ),
     /**
      * Options for configuring the contents of the "meta" field.
      * Ignored if includeMeta is false.

--- a/modules/response/dopamine-response-mvc/src/main/kotlin/io/dopamine/response/mvc/advice/DopamineResponseAdvice.kt
+++ b/modules/response/dopamine-response-mvc/src/main/kotlin/io/dopamine/response/mvc/advice/DopamineResponseAdvice.kt
@@ -2,6 +2,7 @@ package io.dopamine.response.mvc.advice
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.dopamine.core.code.CommonSuccessCode
+import io.dopamine.core.code.ResponseCode
 import io.dopamine.response.common.config.ResponseProperties
 import io.dopamine.response.common.factory.DopamineResponseFactory
 import io.dopamine.response.common.metadata.MetaContributor
@@ -10,11 +11,13 @@ import jakarta.servlet.http.HttpServletRequest
 import org.springframework.core.MethodParameter
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageConverter
 import org.springframework.http.server.ServerHttpRequest
 import org.springframework.http.server.ServerHttpResponse
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.request.ServletRequestAttributes
@@ -56,20 +59,36 @@ class DopamineResponseAdvice(
 
         return when (body) {
             is DopamineResponse<*> -> body
-            else -> {
-                val wrapped =
-                    factory.success(
-                        data = body,
-                        responseCode = CommonSuccessCode.SUCCESS,
-                    )
-                if (returnType.parameterType == String::class.java) {
-                    objectMapper.writeValueAsString(wrapped)
-                } else {
-                    wrapped
-                }
-            }
+            else -> wrapSuccessResponse(body, returnType)
         }
     }
+
+    private fun wrapSuccessResponse(
+        body: Any?,
+        returnType: MethodParameter,
+    ): Any {
+        val status = returnType.getMethodAnnotation(ResponseStatus::class.java)?.value
+        val responseCode = mapStatusToCode(status)
+
+        val response =
+            factory.success(
+                data = body,
+                responseCode = responseCode,
+            )
+        return if (returnType.parameterType == String::class.java) {
+            objectMapper.writeValueAsString(response)
+        } else {
+            response
+        }
+    }
+
+    private fun mapStatusToCode(status: HttpStatus?): ResponseCode =
+        when (status) {
+            HttpStatus.CREATED -> CommonSuccessCode.CREATED
+            HttpStatus.ACCEPTED -> CommonSuccessCode.ACCEPTED
+            HttpStatus.NO_CONTENT -> CommonSuccessCode.NO_CONTENT
+            else -> CommonSuccessCode.SUCCESS
+        }
 
     private fun isReactive(body: Any?): Boolean {
         val className = body?.javaClass?.name ?: return false

--- a/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/controller/SampleController.kt
+++ b/modules/sample/dopamine-starter-mvc-sample/src/main/kotlin/io/dopamine/starter/mvc/sample/controller/SampleController.kt
@@ -1,12 +1,17 @@
 package io.dopamine.starter.mvc.sample.controller
 
+import io.dopamine.response.common.model.DopamineResponse
 import io.dopamine.starter.mvc.sample.dto.SampleDetailDto
 import io.dopamine.starter.mvc.sample.dto.SampleResponseDto
 import io.dopamine.starter.mvc.sample.dto.SampleStatus
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
 
@@ -54,7 +59,7 @@ class SampleController {
     fun getError(): Nothing = throw IllegalStateException("Intentional error for testing.")
 
     @GetMapping("/page")
-    fun getPage(): PageImpl<SampleResponseDto> {
+    fun getPage(): Page<SampleResponseDto> {
         val pageRequest = PageRequest.of(0, 3)
         val content =
             listOf(
@@ -64,4 +69,21 @@ class SampleController {
             )
         return PageImpl(content, pageRequest, 10)
     }
+
+    @GetMapping("/entity")
+    fun getEntity(): ResponseEntity<SampleResponseDto> = ResponseEntity.status(HttpStatus.CREATED).body(getDto())
+
+    @GetMapping("/dopamine")
+    fun getDopamine(): DopamineResponse<SampleResponseDto> =
+        DopamineResponse(
+            code = "SUCCESS",
+            message = "Manual dopamine response",
+            data = getDto(),
+            timestamp = LocalDateTime.now().toString(),
+            meta = emptyMap(),
+        )
+
+    @GetMapping("/status")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun noContent(): String? = null
 }


### PR DESCRIPTION
- Add endpoints using ResponseEntity, DopamineResponse, and @ResponseStatus to SampleController
- Update DopamineResponseAdvice to wrap non-standard responses consistently
- Extend ignorePaths with "/favicon.ico" to avoid noisy 404s in logs