### PR TITLE
ci: integrate GitHub Actions release workflow with JReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release with JReleaser
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up GPG key
+        run: |
+          echo "$SIGNING_KEY" | gpg --batch --import
+          echo "$SIGNING_PUBLIC_KEY" | gpg --batch --import
+
+      - name: Build and publish with JReleaser
+        uses: jreleaser/release-action@v2
+        with:
+          version: 1.19.0
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PUBLIC_KEY: ${{ secrets.SIGNING_PUBLIC_KEY }}
+          SIGNING_KEY_PASSPHRASE: ${{ secrets.SIGNING_KEY_PASSPHRASE }}
+          CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          CENTRAL_PORTAL_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}

--- a/.jreleaser.yml
+++ b/.jreleaser.yml
@@ -1,36 +1,49 @@
 project:
   name: dopamine-starter-mvc
-  version: 0.1.0
-  description: Spring Boot starter for shared infrastructure like response, traceId, i18n, etc.
-  authors: [DaeYong Kim]
+  description: Spring Boot starter for shared infrastructure
+  longDescription: |
+    Spring Boot starter for shared infrastructure like response formatting, 
+    trace ID management, i18n support, etc.
+  authors:
+    - DaeYong Kim
   license: MIT
   inceptionYear: 2025
-
-signing:
-  active: ALWAYS
-  mode: COMMAND
-  command:
-    executable: gpg
-    keyName: "env:SIGNING_KEY_ID"
-    passphrase: "env:SIGNING_KEY_PASSPHRASE"
-
-deploy:
-  maven:
-    central:
-      active: ALWAYS
-      groupId: io.github.liamkim-daeyong
-      artifactId: dopamine-starter-mvc
-      credentials:
-        username: "env:CENTRAL_PORTAL_USERNAME"
-        password: "env:CENTRAL_PORTAL_PASSWORD"
+  links:
+    homepage: https://github.com/LiamKim-DaeYong/dopamine
+    documentation: https://github.com/LiamKim-DaeYong/dopamine/blob/main/README.md
+  java:
+    groupId: io.github.liamkim-daeyong
+    version: 11
 
 release:
   github:
-    active: ALWAYS
-    token: "env:JRELEASER_GITHUB_TOKEN"
+    owner: LiamKim-DaeYong
+    name: dopamine
+    token: "{{envs.JRELEASER_GITHUB_TOKEN}}"
+    tagName: "v{{projectVersion}}"
+    releaseName: "dopamine-starter-mvc v{{projectVersion}} (preview)"
     overwrite: true
-    tagName: v{{projectVersion}}
-    releaseName: dopamine-starter-mvc v{{projectVersion}} (preview)
     changelog:
-      formatted: ALWAYS
       preset: conventional-commits
+      formatted: ALWAYS
+    milestone:
+      close: false
+
+signing:
+  active: ALWAYS
+  armored: true
+  mode: MEMORY
+  publicKey: "{{envs.SIGNING_PUBLIC_KEY}}"
+  secretKey: "{{envs.SIGNING_KEY}}"
+  passphrase: "{{envs.SIGNING_KEY_PASSPHRASE}}"
+
+deploy:
+  maven:
+    mavenCentral:
+      sonatype:
+        active: ALWAYS
+        url: https://central.sonatype.com/api/v1/publisher
+        username: "{{envs.CENTRAL_PORTAL_USERNAME}}"
+        password: "{{envs.CENTRAL_PORTAL_PASSWORD}}"
+        stagingRepositories:
+          - build/jreleaser/staging

--- a/modules/starter/dopamine-starter-mvc/build.gradle.kts
+++ b/modules/starter/dopamine-starter-mvc/build.gradle.kts
@@ -5,9 +5,8 @@ plugins {
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
-
-    id("org.jreleaser") version "1.19.0"
     id("signing")
+    `maven-publish`
 }
 
 dependencies {
@@ -22,10 +21,6 @@ dependencies {
 
 apply<AutoConfigurationImportGeneratorPlugin>()
 
-signing {
-    useGpgCmd()
-}
-
-jreleaser {
-    configFile.set(file("${rootDir}/.jreleaser.yml"))
+tasks.jar {
+    archiveClassifier.set("")
 }


### PR DESCRIPTION
- Add GitHub Actions workflow for full Maven Central release via JReleaser
- Switch signing mode to MEMORY using GitHub secrets
- Configure build.gradle.kts to work with external .jreleaser.yml