### PR TITLE
fix(ci): stabilize GPG signing with ASCII-armored key import and trust configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,14 +37,14 @@ jobs:
       - name: Install gettext for envsubst
         run: sudo apt-get install -y gettext
 
-      - name: Decode and import GPG private key
+      - name: Import GPG private key
         run: |
-          printf "%s" "$SIGNING_KEY" | base64 --decode > private.asc
+          echo "$SIGNING_KEY" > private.asc
           gpg --batch --import private.asc
 
-      - name: Decode and import GPG public key
+      - name: Import GPG public key
         run: |
-          printf "%s" "$SIGNING_PUBLIC_KEY" | base64 --decode > public.asc
+          echo "$SIGNING_PUBLIC_KEY" > public.asc
           gpg --batch --import public.asc
 
       - name: Trust imported GPG key using expect

--- a/.jreleaser.yml
+++ b/.jreleaser.yml
@@ -34,7 +34,9 @@ release:
 signing:
   active: ALWAYS
   armored: true
-  mode: COMMAND
+  mode: MEMORY
+  publicKey: "${SIGNING_PUBLIC_KEY}"
+  secretKey: "${SIGNING_KEY}"
   passphrase: "${SIGNING_KEY_PASSPHRASE}"
 
 deploy:


### PR DESCRIPTION
- removed base64 decoding of GPG keys
- updated signing mode to MEMORY for JReleaser compatibility
- added explicit GPG key trust level setting using expect
- ensured seamless Maven Central release with valid .asc signatures