### PR TITLE
fix(build): configure jreleaser plugin safely after lazy apply

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,9 +102,7 @@ tasks.named("clean") {
     }
 }
 
-afterEvaluate {
-    plugins.apply("org.jreleaser")
-
+pluginManager.withPlugin("org.jreleaser") {
     extensions.configure<JReleaserExtension> {
         gitRootSearch.set(true)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+import org.jreleaser.gradle.plugin.JReleaserExtension
 
 plugins {
     base
@@ -104,7 +105,7 @@ tasks.named("clean") {
 afterEvaluate {
     plugins.apply("org.jreleaser")
 
-    jreleaser {
+    extensions.configure<JReleaserExtension> {
         gitRootSearch.set(true)
     }
 }


### PR DESCRIPTION
- Ensure JReleaser plugin is applied explicitly with plugins.apply(...)
- Use extensions.configure<JReleaserExtension> to avoid unresolved DSL error
- Fixes unresolved reference issue in GitHub Actions environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved plugin configuration handling for better compatibility and lifecycle management. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->