### PR TITLE
fix: resolve multiline string handling error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,15 @@ jobs:
         run: |
           RELEASE_FILE="RELEASE_NOTES/${{ github.ref_name }}.md"
           if [ -f "$RELEASE_FILE" ]; then
-            echo "notes<<EOF" >> $GITHUB_OUTPUT
-            cat "$RELEASE_FILE" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            {
+              echo 'notes<<EOF'
+              cat "$RELEASE_FILE"
+              echo EOF
+            } >> $GITHUB_OUTPUT
+            echo "has_notes=true" >> $GITHUB_OUTPUT
           else
-            echo "notes=Release ${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "notes=" >> $GITHUB_OUTPUT
+            echo "has_notes=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Create GitHub Release


### PR DESCRIPTION
- Use EOF delimiter for proper multiline string output variable handling
- Remove unnecessary base64 encoding/decoding logic
- Unify output variable name (notes_base64 -> notes)
- Fix "Invalid value. Matching delimiter not found 'EOF'" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved how release notes are handled in the workflow for more reliable multi-line output.
  * Added a new indicator to show if release notes are present.
  * Release notes output is now empty if the file is missing, instead of showing a default message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->